### PR TITLE
Fix/preloading strategy

### DIFF
--- a/src/app/dynamic-component-loader/dynamic-component-loader.module.ts
+++ b/src/app/dynamic-component-loader/dynamic-component-loader.module.ts
@@ -1,24 +1,32 @@
-import { ModuleWithProviders, NgModule, NgModuleFactoryLoader, SystemJsNgModuleLoader } from '@angular/core';
+import { ModuleWithProviders, NgModule, NgModuleFactoryLoader, SystemJsNgModuleLoader, Type } from '@angular/core';
 import { ROUTES } from '@angular/router';
 
 import { DynamicComponentLoader } from './dynamic-component-loader.service';
-import { DYNAMIC_COMPONENT_MANIFESTS, DynamicComponentManifest } from './dynamic-component-manifest';
+import { DYNAMIC_COMPONENT, DYNAMIC_COMPONENT_MANIFESTS, DynamicComponentManifest } from './dynamic-component-manifest';
 
-@NgModule({
-  providers: [
-    DynamicComponentLoader,
-    { provide: NgModuleFactoryLoader, useClass: SystemJsNgModuleLoader },
-  ],
-})
+@NgModule()
 export class DynamicComponentLoaderModule {
   static forRoot(manifests: DynamicComponentManifest[]): ModuleWithProviders {
     return {
       ngModule: DynamicComponentLoaderModule,
       providers: [
+        DynamicComponentLoader,
+        { provide: NgModuleFactoryLoader, useClass: SystemJsNgModuleLoader },
         // provider for Angular CLI to analyze
         { provide: ROUTES, useValue: manifests, multi: true },
         // provider for DynamicComponentLoader to analyze
         { provide: DYNAMIC_COMPONENT_MANIFESTS, useValue: manifests },
+      ],
+    };
+  }
+  static forChild(component: Type<any>): ModuleWithProviders {
+    return {
+      ngModule: DynamicComponentLoaderModule,
+      providers: [
+        // provider for @angular/router to parse
+        { provide: ROUTES, useValue: [], multi: true },
+        // provider for DynamicComponentLoader to analyze
+        { provide: DYNAMIC_COMPONENT, useValue: component },
       ],
     };
   }

--- a/src/app/dynamic-component-loader/dynamic-component-loader.module.ts
+++ b/src/app/dynamic-component-loader/dynamic-component-loader.module.ts
@@ -1,4 +1,11 @@
-import { ModuleWithProviders, NgModule, NgModuleFactoryLoader, SystemJsNgModuleLoader, Type } from '@angular/core';
+import {
+    ANALYZE_FOR_ENTRY_COMPONENTS,
+    ModuleWithProviders,
+    NgModule,
+    NgModuleFactoryLoader,
+    SystemJsNgModuleLoader,
+    Type,
+} from '@angular/core';
 import { ROUTES } from '@angular/router';
 
 import { DynamicComponentLoader } from './dynamic-component-loader.service';
@@ -23,6 +30,7 @@ export class DynamicComponentLoaderModule {
     return {
       ngModule: DynamicComponentLoaderModule,
       providers: [
+        { provide: ANALYZE_FOR_ENTRY_COMPONENTS, useValue: component, multi: true },
         // provider for @angular/router to parse
         { provide: ROUTES, useValue: [], multi: true },
         // provider for DynamicComponentLoader to analyze

--- a/src/app/dynamic-modules/message/message.module.ts
+++ b/src/app/dynamic-modules/message/message.module.ts
@@ -1,6 +1,6 @@
 import { NgModule } from '@angular/core';
 
-import { DYNAMIC_COMPONENT } from '../../dynamic-component-loader/dynamic-component-manifest';
+import { DynamicComponentLoaderModule } from '../../dynamic-component-loader/dynamic-component-loader.module';
 import { MessageComponent } from './message.component';
 
 @NgModule({
@@ -8,9 +8,7 @@ import { MessageComponent } from './message.component';
     MessageComponent,
   ],
   imports: [
-  ],
-  providers: [
-    { provide: DYNAMIC_COMPONENT, useValue: MessageComponent },
+    DynamicComponentLoaderModule.forChild(MessageComponent),
   ],
   entryComponents: [
     MessageComponent,

--- a/src/app/dynamic-modules/message/message.module.ts
+++ b/src/app/dynamic-modules/message/message.module.ts
@@ -10,8 +10,5 @@ import { MessageComponent } from './message.component';
   imports: [
     DynamicComponentLoaderModule.forChild(MessageComponent),
   ],
-  entryComponents: [
-    MessageComponent,
-  ],
 })
 export class MessageModule {}


### PR DESCRIPTION
Fixes #2. 

Check out branch **feat/preloading-strategy-example** (adc70a0) to see an example of routing with `PreloadAllModules`. You'll notice that navigating between _V1_ and _V2_ only works with this PR's addition of the following, within `DynamicComponentLoaderModule.forChild(...)`:

```typescript
{ provide: ROUTES, useValue: [], multi: true }
```

---

In addition, now that we have a `forChild()` method, it's trivial to utilize `ANALYZE_FOR_ENTRY_COMPONENTS` to automatically find and register `MessageComponent` as an entryComponent.