### PR TITLE
feat: adding (recursive) submodule loading (incl. example)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,14 @@
         "source-map": "0.5.7",
         "typescript": "2.6.2",
         "webpack-sources": "1.1.0"
+      },
+      "dependencies": {
+        "typescript": {
+          "version": "2.6.2",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.6.2.tgz",
+          "integrity": "sha1-PFtv1/beCRQmkCfwPAlGdY92c6Q=",
+          "dev": true
+        }
       }
     },
     "@angular-devkit/core": {
@@ -42,6 +50,14 @@
       "version": "5.1.3",
       "resolved": "https://registry.npmjs.org/@angular/animations/-/animations-5.1.3.tgz",
       "integrity": "sha512-DlcANlrQ2aaspCZZ6yHdEx1PaLKT1q3/xkdTgoKNTJfj9eautcrEuar8NoH0dkzXuQT0i9GewK6+zsF581rpdQ==",
+      "requires": {
+        "tslib": "1.8.1"
+      }
+    },
+    "@angular/cdk": {
+      "version": "5.2.5",
+      "resolved": "https://registry.npmjs.org/@angular/cdk/-/cdk-5.2.5.tgz",
+      "integrity": "sha512-GN8m1d+VcCE9+Bgwv06Y8YJKyZ0i9ZIq2ZPBcJYt+KVgnVVRg4JkyUNxud07LNsvzOX22DquHqmIZiC4hAG7Ag==",
       "requires": {
         "tslib": "1.8.1"
       }
@@ -169,6 +185,14 @@
       "resolved": "https://registry.npmjs.org/@angular/language-service/-/language-service-5.1.3.tgz",
       "integrity": "sha512-qj5K02LdG637YzqgtQVHVwZbzLHWm2WZOHPthu0M04RjS6bZxD4Ng828IXxFydrxoyTcDO/x0Uy2OAb7+rbBQw==",
       "dev": true
+    },
+    "@angular/material": {
+      "version": "5.2.5",
+      "resolved": "https://registry.npmjs.org/@angular/material/-/material-5.2.5.tgz",
+      "integrity": "sha512-IltfBeTJWnmZehOQNQ7KoFs7MGWuZTe0g21hIitGkusVNt1cIoTD24xKH5jwztjH19c04IgiwonpurMKM6pBCQ==",
+      "requires": {
+        "tslib": "1.8.1"
+      }
     },
     "@angular/platform-browser": {
       "version": "5.1.3",
@@ -1164,6 +1188,7 @@
       "requires": {
         "anymatch": "1.3.2",
         "async-each": "1.0.1",
+        "fsevents": "1.2.4",
         "glob-parent": "2.0.0",
         "inherits": "2.0.3",
         "is-binary-path": "1.0.1",
@@ -3021,6 +3046,542 @@
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "dev": true
+    },
+    "fsevents": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.4.tgz",
+      "integrity": "sha512-z8H8/diyk76B7q5wg+Ud0+CqzcAF3mBBI/bA5ne5zrRUUIvNkJY//D3BqyH571KuAC4Nr7Rw7CjWX4r0y9DvNg==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "nan": "2.10.0",
+        "node-pre-gyp": "0.10.0"
+      },
+      "dependencies": {
+        "abbrev": {
+          "version": "1.1.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "ansi-regex": {
+          "version": "2.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "aproba": {
+          "version": "1.2.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "are-we-there-yet": {
+          "version": "1.1.4",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "delegates": "1.0.0",
+            "readable-stream": "2.3.6"
+          }
+        },
+        "balanced-match": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "brace-expansion": {
+          "version": "1.1.11",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "balanced-match": "1.0.0",
+            "concat-map": "0.0.1"
+          }
+        },
+        "chownr": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "code-point-at": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true
+        },
+        "concat-map": {
+          "version": "0.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "console-control-strings": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true
+        },
+        "core-util-is": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "debug": {
+          "version": "2.6.9",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "deep-extend": {
+          "version": "0.5.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "delegates": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "detect-libc": {
+          "version": "1.0.3",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "fs-minipass": {
+          "version": "1.2.5",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "minipass": "2.2.4"
+          }
+        },
+        "fs.realpath": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "gauge": {
+          "version": "2.7.4",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "aproba": "1.2.0",
+            "console-control-strings": "1.1.0",
+            "has-unicode": "2.0.1",
+            "object-assign": "4.1.1",
+            "signal-exit": "3.0.2",
+            "string-width": "1.0.2",
+            "strip-ansi": "3.0.1",
+            "wide-align": "1.1.2"
+          }
+        },
+        "glob": {
+          "version": "7.1.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
+          }
+        },
+        "has-unicode": {
+          "version": "2.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "iconv-lite": {
+          "version": "0.4.21",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "safer-buffer": "2.1.2"
+          }
+        },
+        "ignore-walk": {
+          "version": "3.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "minimatch": "3.0.4"
+          }
+        },
+        "inflight": {
+          "version": "1.0.6",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "once": "1.4.0",
+            "wrappy": "1.0.2"
+          }
+        },
+        "inherits": {
+          "version": "2.0.3",
+          "bundled": true,
+          "dev": true
+        },
+        "ini": {
+          "version": "1.3.5",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "number-is-nan": "1.0.1"
+          }
+        },
+        "isarray": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "minimatch": {
+          "version": "3.0.4",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "brace-expansion": "1.1.11"
+          }
+        },
+        "minimist": {
+          "version": "0.0.8",
+          "bundled": true,
+          "dev": true
+        },
+        "minipass": {
+          "version": "2.2.4",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "safe-buffer": "5.1.1",
+            "yallist": "3.0.2"
+          }
+        },
+        "minizlib": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "minipass": "2.2.4"
+          }
+        },
+        "mkdirp": {
+          "version": "0.5.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "minimist": "0.0.8"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "nan": {
+          "version": "2.10.0",
+          "resolved": "https://registry.npmjs.org/nan/-/nan-2.10.0.tgz",
+          "integrity": "sha512-bAdJv7fBLhWC+/Bls0Oza+mvTaNQtP+1RyhhhvD95pgUJz6XM5IzgmxOkItJ9tkoCiplvAnXI1tNmmUD/eScyA==",
+          "dev": true,
+          "optional": true
+        },
+        "needle": {
+          "version": "2.2.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "debug": "2.6.9",
+            "iconv-lite": "0.4.21",
+            "sax": "1.2.4"
+          }
+        },
+        "node-pre-gyp": {
+          "version": "0.10.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "detect-libc": "1.0.3",
+            "mkdirp": "0.5.1",
+            "needle": "2.2.0",
+            "nopt": "4.0.1",
+            "npm-packlist": "1.1.10",
+            "npmlog": "4.1.2",
+            "rc": "1.2.7",
+            "rimraf": "2.6.2",
+            "semver": "5.5.0",
+            "tar": "4.4.1"
+          }
+        },
+        "nopt": {
+          "version": "4.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "abbrev": "1.1.1",
+            "osenv": "0.1.5"
+          }
+        },
+        "npm-bundled": {
+          "version": "1.0.3",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "npm-packlist": {
+          "version": "1.1.10",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "ignore-walk": "3.0.1",
+            "npm-bundled": "1.0.3"
+          }
+        },
+        "npmlog": {
+          "version": "4.1.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "are-we-there-yet": "1.1.4",
+            "console-control-strings": "1.1.0",
+            "gauge": "2.7.4",
+            "set-blocking": "2.0.0"
+          }
+        },
+        "number-is-nan": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "object-assign": {
+          "version": "4.1.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "once": {
+          "version": "1.4.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "wrappy": "1.0.2"
+          }
+        },
+        "os-homedir": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "os-tmpdir": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "osenv": {
+          "version": "0.1.5",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "os-homedir": "1.0.2",
+            "os-tmpdir": "1.0.2"
+          }
+        },
+        "path-is-absolute": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "process-nextick-args": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "rc": {
+          "version": "1.2.7",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "deep-extend": "0.5.1",
+            "ini": "1.3.5",
+            "minimist": "1.2.0",
+            "strip-json-comments": "2.0.1"
+          },
+          "dependencies": {
+            "minimist": {
+              "version": "1.2.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            }
+          }
+        },
+        "readable-stream": {
+          "version": "2.3.6",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "2.0.0",
+            "safe-buffer": "5.1.1",
+            "string_decoder": "1.1.1",
+            "util-deprecate": "1.0.2"
+          }
+        },
+        "rimraf": {
+          "version": "2.6.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "glob": "7.1.2"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "safer-buffer": {
+          "version": "2.1.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "sax": {
+          "version": "1.2.4",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "semver": {
+          "version": "5.5.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "set-blocking": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "signal-exit": {
+          "version": "3.0.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "string-width": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "code-point-at": "1.1.0",
+            "is-fullwidth-code-point": "1.0.0",
+            "strip-ansi": "3.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "safe-buffer": "5.1.1"
+          }
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "ansi-regex": "2.1.1"
+          }
+        },
+        "strip-json-comments": {
+          "version": "2.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "tar": {
+          "version": "4.4.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "chownr": "1.0.1",
+            "fs-minipass": "1.2.5",
+            "minipass": "2.2.4",
+            "minizlib": "1.1.0",
+            "mkdirp": "0.5.1",
+            "safe-buffer": "5.1.1",
+            "yallist": "3.0.2"
+          }
+        },
+        "util-deprecate": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "wide-align": {
+          "version": "1.1.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "string-width": "1.0.2"
+          }
+        },
+        "wrappy": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "yallist": {
+          "version": "3.0.2",
+          "bundled": true,
+          "dev": true
+        }
+      }
     },
     "fstream": {
       "version": "1.0.11",
@@ -8502,9 +9063,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.6.2.tgz",
-      "integrity": "sha1-PFtv1/beCRQmkCfwPAlGdY92c6Q=",
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.4.2.tgz",
+      "integrity": "sha1-+DlfhdRZJ2BnyYiqQYN6j4KHCEQ=",
       "dev": true
     },
     "uglify-js": {

--- a/package.json
+++ b/package.json
@@ -13,11 +13,13 @@
   "private": true,
   "dependencies": {
     "@angular/animations": "^5.0.0",
+    "@angular/cdk": "^5.0.0",
     "@angular/common": "^5.0.0",
     "@angular/compiler": "^5.0.0",
     "@angular/core": "^5.0.0",
     "@angular/forms": "^5.0.0",
     "@angular/http": "^5.0.0",
+    "@angular/material": "^5.0.0",
     "@angular/platform-browser": "^5.0.0",
     "@angular/platform-browser-dynamic": "^5.0.0",
     "@angular/router": "^5.0.0",
@@ -44,6 +46,6 @@
     "protractor": "~5.1.2",
     "ts-node": "~3.2.0",
     "tslint": "^5.8.0",
-    "typescript": "^2.6.2"
+    "typescript": "~2.4.2"
   }
 }

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -3,6 +3,7 @@
 <p>Check out the "Network" tab in F12 DevTools.</p>
 
 <p>Then, click "Load!".</p>
+<button type="button" (click)="showDialog()">Show Dialog!</button>
 <button type="button" (click)="loadComponent()">Load!</button>
 
 <div #testOutlet></div>

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,7 +1,9 @@
-import { Component, ViewChild, ViewContainerRef } from '@angular/core';
+import { Component, ViewChild, ViewContainerRef } from '@angular/core'
+import { MatDialog } from '@angular/material'
 
-import { DynamicComponentLoader } from './dynamic-component-loader/dynamic-component-loader.service';
-import { MessageComponent } from './dynamic-modules/message/message.component';
+import { DynamicComponentLoader } from './dynamic-component-loader/dynamic-component-loader.service'
+import { DialogComponent } from './dynamic-modules/dialog/dialog.component'
+import { MessageComponent } from './dynamic-modules/message/message.component'
 
 @Component({
   selector: 'app-root',
@@ -9,20 +11,26 @@ import { MessageComponent } from './dynamic-modules/message/message.component';
 })
 export class AppComponent {
 
-  @ViewChild('testOutlet', {read: ViewContainerRef}) testOutlet: ViewContainerRef;
+  @ViewChild('testOutlet', { read: ViewContainerRef }) testOutlet: ViewContainerRef
 
   constructor(
     private dynamicComponentLoader: DynamicComponentLoader,
-  ) { }
+    private dialog: MatDialog,
+  ) {
+  }
 
   loadComponent() {
     this.dynamicComponentLoader
       .getComponentFactory<MessageComponent>('message')
       .subscribe(componentFactory => {
-        const ref = this.testOutlet.createComponent(componentFactory);
-        ref.changeDetectorRef.detectChanges();
+        const ref = this.testOutlet.createComponent(componentFactory)
+        ref.changeDetectorRef.detectChanges()
       }, error => {
-        console.warn(error);
-      });
+        console.warn(error)
+      })
+  }
+
+  showDialog() {
+    this.dialog.open(DialogComponent)
   }
 }

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -1,8 +1,15 @@
-import { NgModule } from '@angular/core';
-import { BrowserModule } from '@angular/platform-browser';
+import { NgModule } from '@angular/core'
+import { MatDialogModule } from '@angular/material'
+import { BrowserModule } from '@angular/platform-browser'
+import { NoopAnimationsModule } from '@angular/platform-browser/animations'
 
-import { AppComponent } from './app.component';
-import { DynamicComponentLoaderModule, DynamicComponentManifest } from './dynamic-component-loader/dynamic-component-loader.module';
+import { AppComponent } from './app.component'
+import {
+  DynamicComponentLoaderModule,
+  DynamicComponentManifest,
+} from './dynamic-component-loader/dynamic-component-loader.module'
+import { DialogComponent } from './dynamic-modules/dialog/dialog.component'
+import { DialogModule } from './dynamic-modules/dialog/dialog.module'
 
 // This array defines which "componentId" maps to which lazy-loaded module.
 const manifests: DynamicComponentManifest[] = [
@@ -11,7 +18,12 @@ const manifests: DynamicComponentManifest[] = [
     path: 'dynamic-message', // some globally-unique identifier, used internally by the router
     loadChildren: './dynamic-modules/message/message.module#MessageModule',
   },
-];
+  {
+    componentId: 'dialog',
+    path: 'dialog',
+    loadChildren: './dynamic-modules/dialog/dialog.module#DialogModule',
+  },
+]
 
 @NgModule({
   declarations: [
@@ -19,11 +31,20 @@ const manifests: DynamicComponentManifest[] = [
   ],
   imports: [
     BrowserModule,
+    DialogModule,
+
+    MatDialogModule,
+    NoopAnimationsModule,
+
     DynamicComponentLoaderModule.forRoot(manifests),
   ],
   providers: [],
   bootstrap: [
     AppComponent,
   ],
+  entryComponents: [
+    DialogComponent,
+  ],
 })
-export class AppModule { }
+export class AppModule {
+}

--- a/src/app/dynamic-component-loader/dynamic-component-loader.module.ts
+++ b/src/app/dynamic-component-loader/dynamic-component-loader.module.ts
@@ -9,7 +9,12 @@ import {
 import { ROUTES } from '@angular/router';
 
 import { DynamicComponentLoader } from './dynamic-component-loader.service';
-import { DYNAMIC_COMPONENT, DYNAMIC_COMPONENT_MANIFESTS, DynamicComponentManifest } from './dynamic-component-manifest';
+import {
+  DYNAMIC_COMPONENT,
+  DYNAMIC_COMPONENT_MANIFESTS,
+  DYNAMIC_MODULE,
+  DynamicComponentManifest,
+} from './dynamic-component-manifest'
 
 @NgModule()
 export class DynamicComponentLoaderModule {
@@ -25,6 +30,17 @@ export class DynamicComponentLoaderModule {
         { provide: DYNAMIC_COMPONENT_MANIFESTS, useValue: manifests },
       ],
     };
+  }
+  static forModule(manifest: DynamicComponentManifest): ModuleWithProviders {
+    return {
+      ngModule: DynamicComponentLoaderModule,
+      providers: [
+        { provide: ANALYZE_FOR_ENTRY_COMPONENTS, useValue: manifest, multi: true },
+        // provider for @angular/router to parse
+        { provide: ROUTES, useValue: manifest, multi: true },
+        // provider for DynamicComponentLoader to analyze
+        { provide: DYNAMIC_MODULE, useValue: manifest }],
+    }
   }
   static forChild(component: Type<any>): ModuleWithProviders {
     return {

--- a/src/app/dynamic-component-loader/dynamic-component-loader.service.ts
+++ b/src/app/dynamic-component-loader/dynamic-component-loader.service.ts
@@ -1,9 +1,14 @@
-import { ComponentFactory, Inject, Injectable, Injector, NgModuleFactoryLoader } from '@angular/core';
+import { ComponentFactory, Inject, Injectable, Injector, NgModuleFactory, NgModuleFactoryLoader } from '@angular/core'
 import { Observable } from 'rxjs/Observable';
 import { fromPromise as ObservableFromPromise } from 'rxjs/observable/fromPromise';
 import { _throw as ObservableThrow } from 'rxjs/observable/throw';
 
-import { DYNAMIC_COMPONENT, DYNAMIC_COMPONENT_MANIFESTS, DynamicComponentManifest } from './dynamic-component-manifest';
+import {
+  DYNAMIC_COMPONENT,
+  DYNAMIC_COMPONENT_MANIFESTS,
+  DYNAMIC_MODULE,
+  DynamicComponentManifest,
+} from './dynamic-component-manifest'
 
 @Injectable()
 export class DynamicComponentLoader {
@@ -12,7 +17,8 @@ export class DynamicComponentLoader {
     @Inject(DYNAMIC_COMPONENT_MANIFESTS) private manifests: DynamicComponentManifest[],
     private loader: NgModuleFactoryLoader,
     private injector: Injector,
-  ) { }
+  ) {
+  }
 
   /** Retrieve a ComponentFactory, based on the specified componentId (defined in the DynamicComponentManifest array). */
   getComponentFactory<T>(componentId: string, injector?: Injector): Observable<ComponentFactory<T>> {
@@ -22,19 +28,46 @@ export class DynamicComponentLoader {
       return ObservableThrow(`DynamicComponentLoader: Unknown componentId "${componentId}"`);
     }
 
-    const p = this.loader.load(manifest.loadChildren)
-      .then(ngModuleFactory => {
-        const moduleRef = ngModuleFactory.create(injector || this.injector);
-        const dynamicComponentType = moduleRef.injector.get(DYNAMIC_COMPONENT);
-        if (!dynamicComponentType) {
-          throw new Error(
-            `DynamicComponentLoader: Dynamic module for componentId "${componentId}" does not contain DYNAMIC_COMPONENT as a provider.`,
-          );
-        }
+    const path = manifest.loadChildren
 
-        return moduleRef.componentFactoryResolver.resolveComponentFactory<T>(dynamicComponentType);
-      });
+    const p = this.load<T>(path, componentId, injector)
+    return ObservableFromPromise(p)
+  }
 
-    return ObservableFromPromise(p);
+  load<T>(path: string, componentId: string, injector?: Injector): Promise<ComponentFactory<T>> {
+    return this.loader.load(path)
+      .then((ngModuleFactory) => this.loadFactory<T>(ngModuleFactory, componentId, injector))
+  }
+
+  loadFactory<T>(ngModuleFactory: NgModuleFactory<any>, componentId: string, injector?: Injector): Promise<ComponentFactory<T>> {
+    const moduleRef = ngModuleFactory.create(injector || this.injector)
+    const dynamicComponentType = moduleRef.injector.get(DYNAMIC_COMPONENT, null)
+    if (!dynamicComponentType) {
+      const dynamicModule: DynamicComponentManifest = moduleRef.injector.get(DYNAMIC_MODULE, null)
+
+      if (!dynamicModule) {
+        throw new Error(
+          'DynamicComponentLoader: Dynamic module for'
+          + ` componentId "${componentId}" does not contain`
+          + ' DYNAMIC_COMPONENT or DYNAMIC_MODULE as a provider.',
+        )
+      }
+      if (dynamicModule.componentId !== componentId) {
+        throw new Error(
+          'DynamicComponentLoader: Dynamic module for'
+          + `${componentId} does not match manifest.`,
+        )
+      }
+
+      const path = dynamicModule.loadChildren
+
+      if (!path) {
+        throw new Error(`${componentId} unknown!`)
+      }
+
+      return this.load<T>(path, componentId, injector)
+    }
+
+    return Promise.resolve(moduleRef.componentFactoryResolver.resolveComponentFactory<T>(dynamicComponentType))
   }
 }

--- a/src/app/dynamic-component-loader/dynamic-component-manifest.ts
+++ b/src/app/dynamic-component-loader/dynamic-component-manifest.ts
@@ -2,6 +2,8 @@ import { InjectionToken } from '@angular/core';
 
 export const DYNAMIC_COMPONENT = new InjectionToken<any>('DYNAMIC_COMPONENT');
 
+export const DYNAMIC_MODULE = new InjectionToken<any>('DYNAMIC_MODULE')
+
 export const DYNAMIC_COMPONENT_MANIFESTS = new InjectionToken<any>('DYNAMIC_COMPONENT_MANIFESTS');
 
 export interface DynamicComponentManifest {

--- a/src/app/dynamic-modules/dialog/content/content.component.ts
+++ b/src/app/dynamic-modules/dialog/content/content.component.ts
@@ -1,0 +1,17 @@
+import { Component } from '@angular/core'
+import { MatDialogRef } from '@angular/material'
+import { DialogComponent } from '../dialog.component'
+
+@Component({
+  selector: 'app-content-component',
+  template: `
+    <h1>Dynamic Dialog Content!</h1>
+    <button (click)="dialogRef.close()">Close</button>
+  `,
+})
+export class ContentComponent {
+
+  constructor(public dialogRef: MatDialogRef<DialogComponent>) {
+  }
+
+}

--- a/src/app/dynamic-modules/dialog/content/content.module.ts
+++ b/src/app/dynamic-modules/dialog/content/content.module.ts
@@ -1,0 +1,14 @@
+import { NgModule } from '@angular/core'
+import { DynamicComponentLoaderModule } from '../../../dynamic-component-loader/dynamic-component-loader.module'
+import { ContentComponent } from './content.component'
+
+@NgModule({
+  declarations: [
+    ContentComponent,
+  ],
+  imports: [
+    DynamicComponentLoaderModule.forChild(ContentComponent),
+  ],
+})
+export class ContentModule {
+}

--- a/src/app/dynamic-modules/dialog/dialog.component.ts
+++ b/src/app/dynamic-modules/dialog/dialog.component.ts
@@ -1,0 +1,19 @@
+import { Component, ViewChild, ViewContainerRef } from '@angular/core'
+import { DynamicComponentLoader } from '../../dynamic-component-loader/dynamic-component-loader.service'
+
+@Component({
+  selector: 'app-dialog-component',
+  template: '<div #outlet></div>',
+})
+export class DialogComponent {
+
+  @ViewChild('outlet', { read: ViewContainerRef }) _outlet: ViewContainerRef
+
+  constructor(private loader: DynamicComponentLoader) {
+    this.loader.getComponentFactory('dialog')
+      .subscribe(factory =>
+        this._outlet.createComponent(factory)
+          .changeDetectorRef.detectChanges(),
+      )
+  }
+}

--- a/src/app/dynamic-modules/dialog/dialog.module.ts
+++ b/src/app/dynamic-modules/dialog/dialog.module.ts
@@ -1,0 +1,21 @@
+import { NgModule } from '@angular/core'
+import { DynamicComponentLoaderModule } from '../../dynamic-component-loader/dynamic-component-loader.module'
+import { DialogComponent } from './dialog.component'
+
+@NgModule({
+  declarations: [
+    DialogComponent,
+  ],
+  exports: [
+    DialogComponent,
+  ],
+  imports: [
+    DynamicComponentLoaderModule.forModule({
+      componentId: 'dialog',
+      path: 'dialog',
+      loadChildren: './content/content.module#ContentModule',
+    }),
+  ],
+})
+export class DialogModule {
+}


### PR DESCRIPTION
Adding recursive sub-module loading as a proposal.

I'm using your dynamic component loading for a customer project. And there are some feature rich modal dialogs. So dynamically load them would be a fine thing. And Material has it that dialogs need to be loaded at application boot (via entryComponents) which makes it impossible to dynamically load the components. So I came up with the sub-module thingy and it works like charm.